### PR TITLE
Update tb client version to not create primary vlan on topology creation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cisco-open/terraform-provider-dcloud
 go 1.18
 
 require (
-	github.com/cisco-open/dcloud-tb-go-client v1.0.1
+	github.com/cisco-open/dcloud-tb-go-client v1.0.2
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
 	github.com/hashicorp/terraform-plugin-log v0.7.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgI
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
-github.com/cisco-open/dcloud-tb-go-client v1.0.1 h1:LqH/ekYj3o5+2a3q6b4kky0z44rgA/Ny41xAons2VbQ=
-github.com/cisco-open/dcloud-tb-go-client v1.0.1/go.mod h1:D2t685+Qb+uOZWdKunNv5dgEUb/3UgfEE3wSa/V3nY4=
+github.com/cisco-open/dcloud-tb-go-client v1.0.2 h1:Orvd4Cbbqqt/QXAXb3oSKilv9a++fUrZqkdFLVy3eG4=
+github.com/cisco-open/dcloud-tb-go-client v1.0.2/go.mod h1:D2t685+Qb+uOZWdKunNv5dgEUb/3UgfEE3wSa/V3nY4=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
## Description

Use the newer version of TB Client so that the Primary VLAN is not created when the Topology is created

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
